### PR TITLE
Windows support - terminate John cleanly

### DIFF
--- a/helper/helper.pro
+++ b/helper/helper.pro
@@ -1,0 +1,2 @@
+SOURCES +=	main.cpp
+QMAKE_LFLAGS += -static-libgcc -static-libstdc++

--- a/helper/helper.pro
+++ b/helper/helper.pro
@@ -1,2 +1,3 @@
 SOURCES +=	main.cpp
 QMAKE_LFLAGS += -static-libgcc -static-libstdc++
+DESTDIR = ../../johnny_build/

--- a/helper/main.cpp
+++ b/helper/main.cpp
@@ -1,10 +1,16 @@
+#include <QtGlobal>
+#if defined Q_OS_WIN32
 #include <Windows.h>
 #include <wincon.h>
+#endif
 
 int main(int argc, char* argv[])
 {
+#if defined Q_OS_WIN32
     int processId = atoi(argv[1]);
-    AttachConsole(6808); // attach to process console
-    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0); // generate Control+C event
+    AttachConsole(processId); // attach to process console
+    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0); // generate Control+Break event
     FreeConsole();
+#endif
+    return 0;
 }

--- a/helper/main.cpp
+++ b/helper/main.cpp
@@ -6,11 +6,22 @@
 
 int main(int argc, char* argv[])
 {
+    /* On Windows, QProces::terminate() posts a WM_CLOSE message to all toplevel windows
+     * of the process and then to the main thread of the process itself. Console applications like JtR
+     * on Windows that do not run an event loop, or whose event loop does not handle the WM_CLOSE message,
+     * can only be terminated by calling kill(). However, kill() doesn't give you a chance to do some cleanup.
+     * So we use this helper to send a Control+Break event which will terminate cleanly
+     *  the sender(helper.exe) and the receiver(john). In fact, in john
+     * CTRL_XXX events will trigger the sig_handle_abord_ctrl method because of this
+     * SetConsoleCtrlHandler(sig_handle_abort_ctrl, TRUE);
+     * See this thread and next posts http://www.openwall.com/lists/john-dev/2015/05/08/11 */
+
 #if defined Q_OS_WIN32
     int processId = atoi(argv[1]);
     AttachConsole(processId); // attach to process console
     GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0); // generate Control+Break event
     FreeConsole();
 #endif
+
     return 0;
 }

--- a/helper/main.cpp
+++ b/helper/main.cpp
@@ -1,0 +1,10 @@
+#include <Windows.h>
+#include <wincon.h>
+
+int main(int argc, char* argv[])
+{
+    int processId = atoi(argv[1]);
+    AttachConsole(6808); // attach to process console
+    GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, 0); // generate Control+C event
+    FreeConsole();
+}

--- a/johnny.pro
+++ b/johnny.pro
@@ -35,6 +35,8 @@ RESOURCES += \
 OTHER_FILES += \
 	README \
 	LICENSE
+
+DESTDIR = ../johnny_build/
 ## Default build is debug
 #CONFIG -= release
 #CONFIG += debug

--- a/johnnyAll.pro
+++ b/johnnyAll.pro
@@ -1,0 +1,5 @@
+TEMPLATE = subdirs
+SUBDIRS = johnny helper
+
+johnny.file = johnny.pro
+helper.file = helper/helper.pro

--- a/johnnyAll.pro
+++ b/johnnyAll.pro
@@ -1,5 +1,6 @@
 TEMPLATE = subdirs
-SUBDIRS = johnny helper
+SUBDIRS = johnny
+win32: SUBDIRS +=helper
 
 johnny.file = johnny.pro
 helper.file = helper/helper.pro

--- a/johnprocess.cpp
+++ b/johnprocess.cpp
@@ -35,7 +35,8 @@ void JohnProcess::terminate()
         ::kill(-processId(), SIGTERM);
     }
 #elif defined Q_OS_WIN32
-    m_helper.start("helper.exe");
+    // Helper.exe will t
+    m_helper.start("helper.exe " + QString::number(processId()));
 #else
     QProcess::terminate();
 #endif

--- a/johnprocess.cpp
+++ b/johnprocess.cpp
@@ -34,6 +34,8 @@ void JohnProcess::terminate()
          * compatibility with those versions of John for now */
         ::kill(-processId(), SIGTERM);
     }
+#elif defined Q_OS_WIN32
+    m_helper.start("helper.exe");
 #else
     QProcess::terminate();
 #endif

--- a/johnprocess.cpp
+++ b/johnprocess.cpp
@@ -35,7 +35,7 @@ void JohnProcess::terminate()
         ::kill(-processId(), SIGTERM);
     }
 #elif defined Q_OS_WIN32
-    // Helper.exe will t
+    // Helper.exe is necessary to terminate cleanly john on windows(start/pause attack)
     m_helper.start("helper.exe " + QString::number(processId()));
 #else
     QProcess::terminate();

--- a/johnprocess.h
+++ b/johnprocess.h
@@ -27,6 +27,11 @@ public slots:
 
 protected:
     virtual void setupChildProcess();
+
+private:
+#if defined Q_OS_WIN32
+    QProcess m_helper;
+#endif
 };
 
 #endif // JOHNPROCESS_H

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -206,7 +206,7 @@ MainWindow::MainWindow(QSettings &settings)
     m_ui->spinBox_nbOfProcess->setMaximum(QThread::idealThreadCount());
 
     #if !OS_FORK
-    //As of now, fork is only supported on Linux platform
+    //As of now, fork is only supported on unix platforms
         m_ui->widget_Fork->hide();
     #endif
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -157,17 +157,17 @@ MainWindow::MainWindow(QSettings &settings)
     // TODO: Are this checks are enough?
     // TODO: Claim on mkdir fails.
     // TODO: Do not do it on start up. Choose other good time.
-    if (!QDir(QDir::home().filePath(".john")).exists()) {
-        QDir::home().mkdir(".john");
+    if (!QDir(QDir::home().filePath("john")).exists()) {
+        QDir::home().mkdir("john");
     }
-    if (!QDir(QDir(QDir::home().filePath(".john")).filePath("johnny")).exists()) {
-        QDir(QDir::home().filePath(".john")).mkdir("johnny");
+    if (!QDir(QDir(QDir::home().filePath("john")).filePath("johnny")).exists()) {
+        QDir(QDir::home().filePath("john")).mkdir("johnny");
     }
 
     // Session for johnny
     m_session = QDir(
         QDir(QDir::home().filePath(
-                 ".john")).filePath(
+                 "john")).filePath(
                      "johnny")).filePath(
                          "default");
 


### PR DESCRIPTION
On Windows (tested on 8.1), Johnny can't terminate cleanly the main(and only) process of JtR(equivalent of unix sigterm). So, start attack/pause attack don't work.