### PR TITLE
Fix #26

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -333,6 +333,7 @@ bool MainWindow::readPasswdFiles(const QStringList &fileNames)
                     tr("Can't open a temporary file. Your disk might be full."));
             }
         }
+        callJohnShow();
         verifySessionState();
         m_ui->actionCopyToClipboard->setEnabled(true);
         m_ui->actionGuessPassword->setEnabled(true);


### PR DESCRIPTION
I think we should not only show already cracked password from the john.pot file when restoring a session but also when opening any pwd file, don't you think ? #26 